### PR TITLE
Business results screen fixes

### DIFF
--- a/src/components/BusinessResults.js
+++ b/src/components/BusinessResults.js
@@ -51,15 +51,10 @@ const BusinessResults = ({
 
       <div className="wwse-percentages">
         <div className="wwse-row">
-          <p>
-            Employees Covered<br />Under Current System
-          </p>
-          <p>
-            Employees Covered<br />with Whole Washington Health Trust
-          </p>
-        </div>
-        <div className="wwse-row">
           <div className="wwse-col">
+            <p>
+              Employees Covered<br />Under Current System
+            </p>
             <span
               style={rangeStyle}
               className="wwse-percentage wwse-result-percentage"
@@ -68,6 +63,9 @@ const BusinessResults = ({
             </span>
           </div>
           <div className="wwse-col">
+            <p>
+              Employees Covered<br />with Whole Washington Health Trust
+            </p>
             <span className="wwse-percentage wwse-percentage-i1600 wwse-result-percentage">100%</span>
           </div>
         </div>

--- a/src/wwse.css
+++ b/src/wwse.css
@@ -428,7 +428,6 @@
 }
 .wwse-cost-bars-container {
 	width: 100%;
-	border-bottom: 1px solid #686868;
 }
 
 .wwse-color-bar {
@@ -444,7 +443,6 @@
 	align-self: center;
 	padding: 0.5em;
 	background: #d6d6d6;
-	box-shadow: inset 0px 1px 1px rgba(0, 0, 0, 0.2);
 	margin-bottom: 10px;
 }
 
@@ -551,7 +549,6 @@
 	margin: 0 auto;
 	padding-top: 0.5em;
 	padding-bottom: 1em;
-	border-bottom: 1px solid #686868;
 	width: 100%;
 }
 

--- a/src/wwse.css
+++ b/src/wwse.css
@@ -482,6 +482,16 @@
 	font-size: 1em;
 }
 
+.wwse-row p{
+	margin: 1em;
+}
+
+@media (max-width: 767.98px) {
+    .wwse-row {
+        flex-flow: row wrap;
+    }
+}
+
 .wwse-col {
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
Rearranged a couple html elements in the BusinessResults.js file, then revised CSS for those elements in the wwse.css file so that text centers above percentage bubbles and they collapse into a single column on mobile devises.